### PR TITLE
fix: render docstrings for class attributes and constants

### DIFF
--- a/src/docc/plugins/python/cst.py
+++ b/src/docc/plugins/python/cst.py
@@ -560,15 +560,14 @@ class _TransformVisitor(Visitor):
         self.old_stack.append(class_context)
         self.old_stack.append(body_context)
 
-        for idx, cst_statement in enumerate(cst_node.body.body):
-            self.old_stack[-1].child_offset = idx
-            if (
-                isinstance(cst_statement, cst.SimpleStatementLine)
-                and len(cst_statement.body) == 1
-                and isinstance(cst_statement.body[0], cst.Expr)
-                and isinstance(cst_statement.body[0].value, cst.SimpleString)
-            ):
-                continue
+        for index, cst_statement in enumerate(cst_node.body.body):
+            self.old_stack[-1].child_offset = index
+            if isinstance(cst_statement, cst.SimpleStatementLine):
+                if len(cst_statement.body) == 1:
+                    cst_first = cst_statement.body[0]
+                    if isinstance(cst_first, cst.Expr):
+                        if isinstance(cst_first.value, cst.SimpleString):
+                            continue
             statement = body.find_child(cst_statement)
             statement.visit(self)
 


### PR DESCRIPTION
## What was wrong?

https://github.com/SamWilsn/docc/issues/9

## How was it fixed?

- As the cst nodes are traversed, assign the statements index position as the child offset
Since, the child_offset for the cst node is incremented both during enter_class_def and after visiting the node at exit(), incrementing on every iteration sometimes incorrectly assigns different child offset indexes (skipped by 2) 

- while traversing cst, do not revisit docstring lines as statements (since they are attached to their parent attribute)

- For the class body, the cst children starts with a `Index 0: TrailingWhitespace()`, while for modules (outside classes) index starts with constants - selectively handle that when determining the offset of the docstring

## Testing
Verified against different class structures and conditions

Sample Class structures and results
[bytes.py (in src_docc).pdf](https://github.com/user-attachments/files/20773729/bytes.py.in.src_docc.pdf)

