### PR TITLE
<td> inside of <del> and <ins> should have coloured background

### DIFF
--- a/src/docc/plugins/html/static/docc.css
+++ b/src/docc/plugins/html/static/docc.css
@@ -61,7 +61,7 @@ table.verbatim > tbody > tr > th {
     padding: 0 0.5ex;
 }
 
-/* Fix for issue #17: td inside del/ins should have colored backgrounds */
+/* Colored backgrounds for deleted and inserted table cells */
 del > td,
 del td {
     background-color: #ffeef0;


### PR DESCRIPTION
fixes #17 
Before
<img width="1944" height="432" alt="454487637-d879bfdc-0e36-4273-b908-95ef25559f3a" src="https://github.com/user-attachments/assets/d12e0cea-13b2-4b65-a144-981e0597af16" />
After
<img width="1910" height="418" alt="454488704-de0b280a-2a2e-45d2-9a85-04c164d9833a" src="https://github.com/user-attachments/assets/5ca22d5a-ad7f-4895-9789-02c529c66040" />
