### PR TITLE
Render package __init__.py at the directory's index.html

### DIFF
--- a/src/docc/cli.py
+++ b/src/docc/cli.py
@@ -30,6 +30,7 @@ from . import build, context, discover, transform
 from .context import Context
 from .document import Document, Node, OutputNode, Visit, Visitor
 from .performance import measure
+from .plugins.listing import ListingSource
 from .settings import Settings
 from .source import Source
 
@@ -157,6 +158,9 @@ def main(command_line: Sequence[str] | None = None) -> None:
         rmtree(output_root, ignore_errors=True)
 
         with measure("Wrote outputs (%.4f s)", level=logging.INFO):
+            non_listing_outputs: Set[Path] = set()
+            resolved: Dict[Source, Path] = {}
+
             for source, context_ in contexts.items():
                 document = context_[Document]
                 extension = document.extension()
@@ -172,8 +176,24 @@ def main(command_line: Sequence[str] | None = None) -> None:
                 output_path = Path(
                     output_path.with_suffix(output_path.suffix + extension)
                 )
+                resolved[source] = output_path
+                if not isinstance(source, ListingSource):
+                    non_listing_outputs.add(output_path)
+
+            for source, context_ in contexts.items():
+                output_path = resolved.get(source)
+                if output_path is None:
+                    continue
+                if (
+                    isinstance(source, ListingSource)
+                    and output_path in non_listing_outputs
+                ):
+                    # Another source already writes here (e.g. an
+                    # ``__init__.py`` rendered as the package's index page).
+                    continue
 
                 output_path.parent.mkdir(parents=True, exist_ok=True)
 
+                document = context_[Document]
                 with open(output_path, "w", encoding="utf-8") as destination:
                     document.root.visit(_OutputVisitor(context_, destination))

--- a/src/docc/plugins/python/cst.py
+++ b/src/docc/plugins/python/cst.py
@@ -157,10 +157,20 @@ class PythonSource(TextSource):
         return self._relative_path
 
     @property
+    def is_package_init(self) -> bool:
+        """
+        Whether this source is an ``__init__.py`` rendered as the package
+        directory's index page.
+        """
+        return self.absolute_path.name == "__init__.py"
+
+    @property
     def output_path(self) -> PurePath:
         """
         Where to put the output derived from this source.
         """
+        if self.is_package_init:
+            return self._relative_path.parent / "index"
         return self._relative_path
 
     def open(self) -> TextIO:


### PR DESCRIPTION
## Summary
- Route `__init__.py` sources to `<dir>/index` so each package's landing page (`index.html`) is the rendered module documentation instead of an empty directory listing
- Keep the synthetic `ListingSource` in the navigation tree, but skip writing its file in `cli.py` when a non-listing source already covers the same output path — this preserves the `docc/`, `plugins/`, etc. entries in parent listings while letting the module page win at `index.html`
- The module template already renders a leaf siblings listing under "Browse", so the directory listing remains visible on the package's index page

## Example

<img width="1640" height="1296" alt="image" src="https://github.com/user-attachments/assets/0ccd5221-3251-4a7d-83fa-68d93f77185a" />


## Test plan
- [x] `tox -e py3` passes (lint + tests + `docc` self-build)
- [x] `tox -e type` passes (pyre)
- [x] Generated docs no longer contain any `__init__.py.html` files; `index.html` exists for every package and contains the rendered `__init__.py`
- [x] Cross-references and breadcrumbs resolve to `<pkg>/index.html`
- [x] Parent listings still link to subpackages (e.g. `src/index.html` lists `docc/`)

